### PR TITLE
chore: limit the CI to master and tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,11 @@ cache:
   directories:
     - node_modules
 
+branches:
+  only:
+    - master
+    - /^v\d+\.\d+(\.\d+)?(-\S*)?$/
+
 script:
   - npm run build
 


### PR DESCRIPTION
The change remove the double build for PR from the main repo branches.