### PR TITLE
Fix headings for sizes 4 and 5

### DIFF
--- a/src/components/Heading.tsx
+++ b/src/components/Heading.tsx
@@ -30,27 +30,27 @@ export const Heading = React.forwardRef<HTMLHeadingElement, HeadingProps>((props
             textIndent: '-.05em',
           },
           1: {
-            fontSize: 5,
+            fontSize: 4,
             letterSpacing: '-.005em',
             textIndent: '-.06em',
           },
           2: {
-            fontSize: 7,
+            fontSize: 5,
             letterSpacing: '-.012em',
             textIndent: '-.075em',
           },
           3: {
-            fontSize: 8,
+            fontSize: 6,
             letterSpacing: '-.028em',
             textIndent: '-.085em',
           },
           4: {
-            fontSize: 9,
+            fontSize: 7,
             letterSpacing: '-.042em',
             textIndent: '-.088em',
           },
           5: {
-            fontSize: 10,
+            fontSize: 8,
             letterSpacing: '-.052em',
             textIndent: '-.09em',
           },


### PR DESCRIPTION
@matthieuh, I noticed that it seems we don't have 9 or 10 available for the `fontSize` property. So then I redistributed the sizes to be incremental from 3 to 8, which seems to be our biggest possible value, and equivalent to 72px. Thoughts?

This is the final result after this change:

![image](https://user-images.githubusercontent.com/38889364/70180542-0237d700-16bf-11ea-83a8-026fbef371b0.png)