### PR TITLE
fix: enable builds on *@*.*.* tags instead of v*.*.*

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "packages": ["packages/*"],
-  "version": "independent",
+  "version": "0.3.3",
   "npmClient": "yarn",
   "useWorkspaces": true
 }


### PR DESCRIPTION
**Reason:** Build is not triggered with tags like this one: `@containous/faency@0.4.0` due to the new monorepo architecture