### PR TITLE
Proposal: Add default value to Description column in Docs

### DIFF
--- a/packages/website/src/components/PropsTable.js
+++ b/packages/website/src/components/PropsTable.js
@@ -33,7 +33,10 @@ export function PropsTable({ data, title = 'Props' }) {
                       <Chip variant="blue">{value.type}</Chip>
                     </Td>
                     <Td>
-                      <Text>{value.description}</Text>
+                      <Text>
+                        {value.description}
+                        {value.default && ` (Default: '${value.default}')`}
+                      </Text>
                     </Td>
                   </Tr>
                 )
@@ -50,5 +53,9 @@ export function PropsTable({ data, title = 'Props' }) {
 
 PropsTable.propTypes = {
   title: PropTypes.string,
-  data: PropTypes.object,
+  data: PropTypes.shape({
+    type: PropTypes.string.isRequired,
+    description: PropTypes.string.isRequired,
+    default: PropTypes.string,
+  }),
 }


### PR DESCRIPTION
I noticed that we have a possible field called `default` on the `PropsTable`, but it was not used when displaying the items.
I thought we could add it like this, what do you think?

![image](https://user-images.githubusercontent.com/38889364/76370892-20911c80-6317-11ea-967a-d61f4f76c6a8.png)

If the value has no default, it just doesn't show it, like this:

![image](https://user-images.githubusercontent.com/38889364/76371067-cb093f80-6317-11ea-8808-ee0cf65e379a.png)
