### PR TITLE
Export all types from Components and from Faency index

### DIFF
--- a/packages/faency/src/components/Avatar.tsx
+++ b/packages/faency/src/components/Avatar.tsx
@@ -2,7 +2,7 @@ import React, { useContext, forwardRef } from 'react'
 import { Avatar as AvatarPrimitive, AvatarProps as AvatarPrimitiveProps } from '@modulz/primitives'
 import { ThemeContext } from 'styled-components'
 
-type AvatarProps = AvatarPrimitiveProps & {
+export type AvatarProps = AvatarPrimitiveProps & {
   textColor?: string
   variant?: 'normal' | 'dark' | 'light'
 }

--- a/packages/faency/src/components/Box.tsx
+++ b/packages/faency/src/components/Box.tsx
@@ -1,1 +1,1 @@
-export { Box } from '@modulz/primitives'
+export { Box, BoxProps } from '@modulz/primitives'

--- a/packages/faency/src/components/Button.tsx
+++ b/packages/faency/src/components/Button.tsx
@@ -8,7 +8,7 @@ import { transparentize } from 'polished'
 type Variant = 'gray' | 'blue' | 'green' | 'red' | 'transparent' | 'primary' | 'secondary'
 type Size = 0 | 1
 
-type ButtonProps = ButtonPrimitiveProps & {
+export type ButtonProps = ButtonPrimitiveProps & {
   variant?: Variant
   isWaiting?: boolean
   size?: Size

--- a/packages/faency/src/components/Card.tsx
+++ b/packages/faency/src/components/Card.tsx
@@ -30,7 +30,7 @@ function createShadow(defaultOpacity: number): CSSObject {
 
 export type Variant = 'border' | 'shadow' | 'ghost'
 
-type CardProps = CardPrimitiveProps & {
+export type CardProps = CardPrimitiveProps & {
   variant?: Variant
   as?: any
 }

--- a/packages/faency/src/components/Checkbox.tsx
+++ b/packages/faency/src/components/Checkbox.tsx
@@ -2,6 +2,8 @@ import React from 'react'
 import { theme } from '../theme'
 import { Checkbox as CheckboxPrimitive, CheckboxProps } from '@modulz/primitives'
 
+export { CheckboxProps } from '@modulz/primitives'
+
 export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>((props, forwardedRef) => (
   <CheckboxPrimitive
     {...props}

--- a/packages/faency/src/components/Flex.tsx
+++ b/packages/faency/src/components/Flex.tsx
@@ -1,1 +1,1 @@
-export { Flex } from '@modulz/primitives'
+export { Flex, FlexProps } from '@modulz/primitives'

--- a/packages/faency/src/components/FormMessage.tsx
+++ b/packages/faency/src/components/FormMessage.tsx
@@ -22,7 +22,7 @@ const ColoredMessage = styled(Text)<{ color: string }>`
   `}
 `
 
-type FormMessageProps = {
+export type FormMessageProps = {
   message: string
   variant?: 'error' | 'warning' | 'info' | 'success'
   hasIcon?: boolean

--- a/packages/faency/src/components/InputTags.tsx
+++ b/packages/faency/src/components/InputTags.tsx
@@ -115,7 +115,7 @@ const defaultRenderOption: RenderOptionType = (option, onClick) => (
   </SelectItem>
 )
 
-interface InputTagsProps {
+export type InputTagsProps = {
   value?: string
   placeholder?: string
   tags?: string[]

--- a/packages/faency/src/components/Loading.tsx
+++ b/packages/faency/src/components/Loading.tsx
@@ -2,7 +2,7 @@ import styled, { css as _css, keyframes, SimpleInterpolation } from 'styled-comp
 import { Box, BoxProps as BoxPrimitiveProps } from '@modulz/primitives'
 import { theme } from '../theme'
 
-type LoadingProps = BoxPrimitiveProps & {
+export type LoadingProps = BoxPrimitiveProps & {
   progress?: number
 }
 

--- a/packages/faency/src/components/Nav/Nav.tsx
+++ b/packages/faency/src/components/Nav/Nav.tsx
@@ -16,13 +16,13 @@ import MenuIcon from './components/MenuIcon'
 import Menu, { NavContainer } from './components/Menu'
 export { NavContainer }
 
-type NavItemProps = ButtonPrimitiveProps &
+export type NavItemProps = ButtonPrimitiveProps &
   LinkPrimitiveProps & {
     as?: 'button' | 'a'
     variant?: 'active' | 'normal'
   }
 
-type NavGroupProps = {
+export type NavGroupProps = {
   variant?: 'left' | 'right'
 }
 
@@ -132,11 +132,11 @@ const ResponsiveWrapper = styled.div`
   }
 `
 
-type NavGroupsProps = {
+export type NavGroupsProps = {
   children: React.ReactNode
 }
 
-type NavProps = {
+export type NavProps = {
   children: React.ReactNode
 }
 

--- a/packages/faency/src/components/Nav/index.ts
+++ b/packages/faency/src/components/Nav/index.ts
@@ -1,1 +1,11 @@
-export { Nav, NavContainer, NavGroups, NavGroup, NavItem } from './Nav'
+export {
+  Nav,
+  NavContainer,
+  NavGroups,
+  NavGroup,
+  NavItem,
+  NavGroupProps,
+  NavGroupsProps,
+  NavItemProps,
+  NavProps,
+} from './Nav'

--- a/packages/faency/src/components/Radio.tsx
+++ b/packages/faency/src/components/Radio.tsx
@@ -2,6 +2,8 @@ import React from 'react'
 import { Radio as RadioPrimitive, RadioProps } from '@modulz/primitives'
 import { theme } from '../theme'
 
+export { RadioProps } from '@modulz/primitives'
+
 export const Radio = React.forwardRef<HTMLInputElement, RadioProps>((props, forwardedRef) => (
   <RadioPrimitive
     {...props}

--- a/packages/faency/src/components/Skeleton.tsx
+++ b/packages/faency/src/components/Skeleton.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import themeGet from '@styled-system/theme-get'
 import styled, { keyframes } from 'styled-components'
-import { transparentize } from 'polished'
 import { Box as BoxPrimitive } from '../components/Box'
 
 const shimmerAnimation = keyframes`
@@ -13,7 +12,7 @@ const shimmerAnimation = keyframes`
   }
 `
 
-type SkeletonTextProps = {
+export type SkeletonTextProps = {
   size?: 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8
 }
 
@@ -51,7 +50,7 @@ SkeletonText.defaultProps = {
   size: 2,
 }
 
-type SkeletonTextGroupProps = {
+export type SkeletonTextGroupProps = {
   lines?: number
 }
 

--- a/packages/faency/src/components/SubNav.tsx
+++ b/packages/faency/src/components/SubNav.tsx
@@ -5,7 +5,7 @@ import { transparentize } from 'polished'
 import { theme } from '../theme'
 import breakpoints from '../breakpoints'
 
-type SubNavItemProps = {
+export type SubNavItemProps = {
   as?: 'button' | 'a'
   variant?: 'active' | 'normal'
 }

--- a/packages/faency/src/components/Tooltip/index.ts
+++ b/packages/faency/src/components/Tooltip/index.ts
@@ -1,1 +1,1 @@
-export { Tooltip } from './Tooltip'
+export { Tooltip, TooltipProps } from './Tooltip'

--- a/packages/faency/src/index.ts
+++ b/packages/faency/src/index.ts
@@ -1,21 +1,31 @@
 export { Provider } from './Provider'
 
-export { Avatar } from './components/Avatar'
-export { Box } from './components/Box'
-export { Button } from './components/Button'
-export { Card } from './components/Card'
-export { CardLink } from './components/CardLink'
-export { Checkbox } from './components/Checkbox'
-export { Chip } from './components/Chip'
+export { Avatar, AvatarProps } from './components/Avatar'
+export { Box, BoxProps } from './components/Box'
+export { Button, ButtonProps } from './components/Button'
+export { Card, CardProps } from './components/Card'
+export { CardLink, CardLinkProps } from './components/CardLink'
+export { Checkbox, CheckboxProps } from './components/Checkbox'
+export { Chip, ChipProps } from './components/Chip'
 export { DropdownMenu, DropdownMenuProps } from './components/DropdownMenu'
-export { Flex } from './components/Flex'
+export { Flex, FlexProps } from './components/Flex'
 export { Grid, GridProps } from './components/Grid'
-export { Heading } from './components/Heading'
-export { Input } from './components/Input'
-export { InputTags } from './components/InputTags'
-export { FormMessage } from './components/FormMessage'
-export { Loading } from './components/Loading'
-export { Nav, NavContainer, NavItem, NavGroups, NavGroup } from './components/Nav'
+export { Heading, HeadingProps } from './components/Heading'
+export { Input, InputProps } from './components/Input'
+export { InputTags, InputTagsProps } from './components/InputTags'
+export { FormMessage, FormMessageProps } from './components/FormMessage'
+export { Loading, LoadingProps } from './components/Loading'
+export {
+  Nav,
+  NavContainer,
+  NavGroups,
+  NavGroup,
+  NavItem,
+  NavGroupProps,
+  NavGroupsProps,
+  NavItemProps,
+  NavProps,
+} from './components/Nav'
 export {
   Menu,
   MenuProps,
@@ -32,15 +42,21 @@ export {
   MenuItemSeparator,
   MenuItemSeparatorProps,
 } from './components/Menu'
-export { Radio } from './components/Radio'
-export { Option, OptionProps, OptionGroup, OptionGroupProps, Select } from './components/Select'
-export { SkeletonBox, SkeletonText, SkeletonTextGroup } from './components/Skeleton'
-export { SubNav, SubNavItem } from './components/SubNav'
+export { Radio, RadioProps } from './components/Radio'
+export { Option, OptionProps, OptionGroup, OptionGroupProps, Select, SelectProps } from './components/Select'
+export {
+  SkeletonBox,
+  SkeletonText,
+  SkeletonTextGroup,
+  SkeletonTextProps,
+  SkeletonTextGroupProps,
+} from './components/Skeleton'
+export { SubNav, SubNavItem, SubNavItemProps } from './components/SubNav'
 export { Switch, SwitchProps } from './components/Switch'
 export { Table, Thead, Tbody, Tfoot, Tr, Th, Td } from './components/Table'
-export { Text } from './components/Text'
-export { ToggleButtonGroup, ToggleButton } from './components/ToggleButton'
-export { Tooltip } from './components/Tooltip'
+export { Text, TextProps } from './components/Text'
+export { ToggleButtonGroup, ToggleButton, ToggleButtonGroupProps } from './components/ToggleButton'
+export { Tooltip, TooltipProps } from './components/Tooltip'
 
 export { theme } from './theme'
 export { useTheme } from './hooks/use-theme'


### PR DESCRIPTION
There were some type declarations that were not exported yet, so this PR exports all types from components and adds them to the Faency `index.ts`.