### PR TITLE
refactor: upgrade modulz-primitives

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
       "eslint --fix",
       "git add"
     ],
-    "*.{md,mdx,json}": [
+    "*.{md,json}": [
       "prettier --write",
       "git add"
     ]

--- a/packages/faency/package.json
+++ b/packages/faency/package.json
@@ -39,11 +39,12 @@
     "test:watch": "jest --watch"
   },
   "peerDependencies": {
-    "react": "^16.8.6",
-    "react-dom": "^16.8.6"
+    "react": "^16.12.0",
+    "react-dom": "^16.12.0"
   },
   "dependencies": {
-    "@modulz/primitives": "^0.0.1-14",
+    "@modulz/primitives": "^0.0.1-20",
+    "@modulz/radix-system": "0.0.1-alpha.11",
     "@styled-system/css": "5.1.4",
     "@styled-system/theme-get": "5.1.2",
     "@styled-system/variant": "^5.1.4",

--- a/packages/faency/src/components/Avatar.story.tsx
+++ b/packages/faency/src/components/Avatar.story.tsx
@@ -21,54 +21,56 @@ storiesOf('Components|Avatar', module).add('default', () => {
           KS
         </Avatar>
         <Avatar src="">
-          <Text textColor="white" marginBottom={1}>
+          <Text sx={{ color: 'white' }} mb={1}>
             K
           </Text>
-          <Text textColor="white" marginTop={1}>
+          <Text sx={{ color: 'white' }} mt={1}>
             S
           </Text>
         </Avatar>
       </Box>
 
-      <Box mb={4} backgroundColor="white" padding={2}>
+      <Box mb={4} sx={{ backgroundColor: 'white' }} p={2}>
         <Heading>Avatar using existing image on a light variant</Heading>
         <Avatar src={SAMPLE_IMAGE} variant="light">
           KS
         </Avatar>
       </Box>
 
-      <Box mb={4} backgroundColor="white" padding={2}>
+      <Box mb={4} sx={{ backgroundColor: 'white' }} p={2}>
         <Heading>Avatar using non-existing image with fallback to initials on a light variant</Heading>
         <Avatar mr={1} src="" variant="light">
           KS
         </Avatar>
         <Avatar src="" variant="light">
-          <Text textColor="white" marginBottom={1}>
+          <Text sx={{ color: 'white' }} mb={1}>
             K
           </Text>
-          <Text textColor="white" marginTop={1}>
+          <Text sx={{ color: 'white' }} mt={1}>
             S
           </Text>
         </Avatar>
       </Box>
 
-      <Box mb={4} backgroundColor="dark" padding={2}>
-        <Heading textColor="white">Avatar using existing image on a dark variant</Heading>
+      <Box mb={4} sx={{ backgroundColor: 'dark' }} p={2}>
+        <Heading sx={{ color: 'white' }}>Avatar using existing image on a dark variant</Heading>
         <Avatar src={SAMPLE_IMAGE} variant="dark">
           KS
         </Avatar>
       </Box>
 
-      <Box mb={4} backgroundColor="dark" padding={2}>
-        <Heading textColor="white">Avatar using non-existing image with fallback to initials on a dark variant</Heading>
+      <Box mb={4} sx={{ backgroundColor: 'dark' }} p={2}>
+        <Heading sx={{ color: 'white' }}>
+          Avatar using non-existing image with fallback to initials on a dark variant
+        </Heading>
         <Avatar mr={1} src="" variant="dark">
           KS
         </Avatar>
         <Avatar src="" variant="dark">
-          <Text textColor="white" marginBottom={1}>
+          <Text sx={{ color: 'white' }} mb={1}>
             K
           </Text>
-          <Text textColor="white" marginTop={1}>
+          <Text sx={{ color: 'white' }} mt={1}>
             S
           </Text>
         </Avatar>

--- a/packages/faency/src/components/Avatar.tsx
+++ b/packages/faency/src/components/Avatar.tsx
@@ -3,7 +3,6 @@ import { Avatar as AvatarPrimitive, AvatarProps as AvatarPrimitiveProps } from '
 import { ThemeContext } from 'styled-components'
 
 export type AvatarProps = AvatarPrimitiveProps & {
-  textColor?: string
   variant?: 'normal' | 'dark' | 'light'
 }
 
@@ -27,7 +26,7 @@ export const Avatar = forwardRef<HTMLSpanElement, AvatarProps>((props, forwarded
               color: '#fff',
               transition: 'all 200ms ease-in-out',
               '*': {
-                color: '#fff !important',
+                color: '#fff',
               },
             },
           },

--- a/packages/faency/src/components/Box.story.tsx
+++ b/packages/faency/src/components/Box.story.tsx
@@ -5,30 +5,28 @@ import { Box } from './Box'
 storiesOf('Components|Box', module).add('default', () => (
   <>
     <Box mb={4}>
-      <Box width={120} height={120} bg="blue" />
+      <Box sx={{ width: 120, height: 120, bg: 'blue' }} />
     </Box>
     <Box mb={4}>
-      <Box p="4" bg="black">
-        <Box height={50} bg="blue" mb="4" />
-        <Box height={50} bg="blue" mb="4" />
-        <Box height={50} bg="blue" />
+      <Box p="4" sx={{ bg: 'black' }}>
+        <Box sx={{ height: 50, bg: 'blue' }} mb="4" />
+        <Box sx={{ height: 50, bg: 'blue' }} mb="4" />
+        <Box sx={{ height: 50, bg: 'blue' }} />
       </Box>
     </Box>
 
-    <Box border="4px solid" borderColor="reds.6" bg="reds.4" height={50} padding={1} margin={4} />
+    <Box sx={{ border: '4px solid', borderColor: 'reds.6', bg: 'reds.4', height: 50, padding: 1, margin: 4 }} />
 
-    <Box my={4} position="relative" width="100%" height="200px" bg="black">
-      <Box bg="blue" padding={5} position="absolute" top="10px" left="10px" zIndex={1} />
-      <Box bg="blues.6" padding={5} position="absolute" top="15px" left="15px" />
+    <Box my={4} sx={{ position: 'relative', width: '100%', height: '200px', bg: 'black' }}>
+      <Box p={5} sx={{ bg: 'blue', position: 'absolute', top: '10px', left: '10px', zIndex: 1 }} />
+      <Box p={5} sx={{ bg: 'blues.6', position: 'absolute', top: '15px', left: '15px' }} />
       Hello
     </Box>
 
-    <Box my={4} p={4} bg="black" textColor="blue">
+    <Box my={4} p={4} sx={{ bg: 'black', color: 'blue' }}>
       Faency
     </Box>
 
-    <Box flexShrink={0} flexGrow={1} flexBasis="100%">
-      Testing flex
-    </Box>
+    <Box sx={{ flexShrink: 0, flexGrow: 1, flexBasis: '100%' }}>Testing flex</Box>
   </>
 ))

--- a/packages/faency/src/components/Card.story.tsx
+++ b/packages/faency/src/components/Card.story.tsx
@@ -8,7 +8,7 @@ import { Flex } from './Flex'
 storiesOf('Components|Card', module).add('default', () => (
   <>
     <Flex>
-      <Card m={4} maxWidth="300px">
+      <Card m={4} sx={{ maxWidth: '300px' }}>
         <Heading size={1} mb="3">
           Card
         </Heading>
@@ -21,7 +21,7 @@ storiesOf('Components|Card', module).add('default', () => (
           Today
         </Text>
       </Card>
-      <Card variant="shadow" m={4} maxWidth="300px">
+      <Card variant="shadow" m={4} sx={{ maxWidth: '300px' }}>
         <Heading size={1} mb="3">
           Card
         </Heading>
@@ -34,7 +34,7 @@ storiesOf('Components|Card', module).add('default', () => (
           Today
         </Text>
       </Card>
-      <Card variant="ghost" m={4} maxWidth="300px">
+      <Card variant="ghost" m={4} sx={{ maxWidth: '300px' }}>
         <Heading size={1} mb="3">
           Card
         </Heading>

--- a/packages/faency/src/components/CardLink.story.tsx
+++ b/packages/faency/src/components/CardLink.story.tsx
@@ -11,7 +11,7 @@ storiesOf('Components|CardLink', module).add('default', () => (
       href="https://jaxenter.com/containous-ambassador-program-traefik-164647.html"
       target="_blank"
       m={4}
-      maxWidth="300px"
+      sx={{ maxWidth: '300px' }}
     >
       <Heading size={1} mb="3">
         CardLink
@@ -30,7 +30,7 @@ storiesOf('Components|CardLink', module).add('default', () => (
       target="_blank"
       variant="shadow"
       m={4}
-      maxWidth="300px"
+      sx={{ maxWidth: '300px' }}
     >
       <Heading size={1} mb="3">
         CardLink
@@ -49,7 +49,7 @@ storiesOf('Components|CardLink', module).add('default', () => (
       target="_blank"
       variant="ghost"
       m={4}
-      maxWidth="300px"
+      sx={{ maxWidth: '300px' }}
     >
       <Heading size={1} mb="3">
         CardLink

--- a/packages/faency/src/components/Chip.story.tsx
+++ b/packages/faency/src/components/Chip.story.tsx
@@ -7,12 +7,12 @@ import { Table, Tr, Th, Td } from './Table'
 
 storiesOf('Components|Chip', module).add('default', () => (
   <>
-    <Flex mb="2" flexWrap="wrap">
+    <Flex mb="2" sx={{ flexWrap: 'wrap' }}>
       <Chip mr={1}>Default Chip</Chip>
       <Chip mr={1}>1</Chip>
       <Chip>123</Chip>
     </Flex>
-    <Flex mb="2" maxWidth="150px">
+    <Flex mb="2" sx={{ maxWidth: '150px' }}>
       <Chip truncate title="Some very long text that could be collapsed or truncated">
         Some very long text that could be collapsed or truncated
       </Chip>
@@ -51,7 +51,7 @@ storiesOf('Components|Chip', module).add('default', () => (
 
 storiesOf('Components|Chip', module).add('colors', () => (
   <>
-    <Flex mb="2" flexWrap="wrap">
+    <Flex mb="2" sx={{ flexWrap: 'wrap' }}>
       <Chip mr={2} variant="blue">
         Blue chip
       </Chip>
@@ -59,7 +59,7 @@ storiesOf('Components|Chip', module).add('colors', () => (
         Purple chip
       </Chip>
     </Flex>
-    <Flex mb="2" flexWrap="wrap">
+    <Flex mb="2" sx={{ flexWrap: 'wrap' }}>
       <Chip mr={2} variant="orange">
         Orange chip
       </Chip>
@@ -67,7 +67,7 @@ storiesOf('Components|Chip', module).add('colors', () => (
         Light blue chip
       </Chip>
     </Flex>
-    <Flex mb="2" flexWrap="wrap">
+    <Flex mb="2" sx={{ flexWrap: 'wrap' }}>
       <Chip mr={2} variant="green">
         Green chip
       </Chip>
@@ -75,7 +75,7 @@ storiesOf('Components|Chip', module).add('colors', () => (
         Gray chip
       </Chip>
     </Flex>
-    <Flex mb="2" flexWrap="wrap">
+    <Flex mb="2" sx={{ flexWrap: 'wrap' }}>
       <Chip mr={2} variant="red">
         Red chip
       </Chip>

--- a/packages/faency/src/components/Flex.story.tsx
+++ b/packages/faency/src/components/Flex.story.tsx
@@ -7,17 +7,17 @@ storiesOf('Components|Flex', module).add('default', () => (
   <>
     <Box mb={4}>
       <Flex p="4" bg="black">
-        <Box flex="1" height={50} bg="blue" m="4" />
-        <Box flex="1" height={50} bg="blue" m="4" />
-        <Box flex="1" height={50} bg="blue" m="4" />
+        <Box sx={{ flex: 1, height: 50, bg: 'blue' }} m="4" />
+        <Box sx={{ flex: 1, height: 50, bg: 'blue' }} m="4" />
+        <Box sx={{ flex: 1, height: 50, bg: 'blue' }} m="4" />
       </Flex>
     </Box>
 
     <Box mb={4}>
-      <Flex p="4" bg="black" flexWrap="wrap">
-        <Box flex="1 1 100%" height={50} bg="blue" m="4" />
-        <Box flex="1" height={50} bg="blue" m="4" />
-        <Box flex="1" height={50} bg="blue" m="4" />
+      <Flex p="4" sx={{ bg: 'black', flexWrap: 'wrap' }}>
+        <Box sx={{ flex: '1 1 100%', height: 50, bg: 'blue' }} m="4" />
+        <Box sx={{ flex: 1, height: 50, bg: 'blue' }} m="4" />
+        <Box sx={{ flex: 1, height: 50, bg: 'blue' }} m="4" />
       </Flex>
     </Box>
   </>

--- a/packages/faency/src/components/FormMessage.tsx
+++ b/packages/faency/src/components/FormMessage.tsx
@@ -50,7 +50,7 @@ const variantProps = {
 
 export const FormMessage = React.forwardRef<HTMLDivElement, FormMessageProps>(
   ({ message, variant = 'error', hasIcon, icon }, forwardedRef) => (
-    <Flex ref={forwardedRef} alignItems="center">
+    <Flex ref={forwardedRef} sx={{ alignItems: 'center' }}>
       {icon ||
         (hasIcon && (
           <IconContainer color={variantProps[variant].color}>

--- a/packages/faency/src/components/Grid.story.tsx
+++ b/packages/faency/src/components/Grid.story.tsx
@@ -5,50 +5,50 @@ import { Grid } from './Grid'
 
 storiesOf('Components|Grid', module).add('default', () => (
   <>
-    <Box mb={4} maxWidth={450}>
-      <Grid gridTemplateColumns="repeat(2, 1fr)" gridGap={4} mb={2}>
+    <Box mb={4} sx={{ maxWidth: 450 }}>
+      <Grid sx={{ gridTemplateColumns: 'repeat(2, 1fr)', gridGap: 4 }} mb={2}>
         <div>
-          <Box bg="blue" p={1} />
+          <Box sx={{ bg: 'blue' }} p={1} />
         </div>
         <div>
-          <Box bg="blue" p={1} />
-        </div>
-      </Grid>
-      <Grid gridTemplateColumns="repeat(5, 1fr)" gridGap={4} mb={2}>
-        <div>
-          <Box bg="blue" p={1} />
-        </div>
-        <div>
-          <Box bg="blue" p={1} />
-        </div>
-        <div>
-          <Box bg="blue" p={1} />
-        </div>
-        <div>
-          <Box bg="blue" p={1} />
-        </div>
-        <div>
-          <Box bg="blue" p={1} />
+          <Box sx={{ bg: 'blue' }} p={1} />
         </div>
       </Grid>
-      <Grid gridTemplateColumns="repeat(3, 1fr)" gridGap={4}>
+      <Grid sx={{ gridTemplateColumns: 'repeat(5, 1fr)', gridGap: 4 }} mb={2}>
         <div>
-          <Box bg="blue" p={1} />
+          <Box sx={{ bg: 'blue' }} p={1} />
         </div>
         <div>
-          <Box bg="blue" p={1} />
+          <Box sx={{ bg: 'blue' }} p={1} />
         </div>
         <div>
-          <Box bg="blue" p={1} />
+          <Box sx={{ bg: 'blue' }} p={1} />
         </div>
         <div>
-          <Box bg="blue" p={1} />
+          <Box sx={{ bg: 'blue' }} p={1} />
         </div>
         <div>
-          <Box bg="blue" p={1} />
+          <Box sx={{ bg: 'blue' }} p={1} />
+        </div>
+      </Grid>
+      <Grid sx={{ gridTemplateColumns: 'repeat(3, 1fr)', gridGap: 4 }}>
+        <div>
+          <Box sx={{ bg: 'blue' }} p={1} />
         </div>
         <div>
-          <Box bg="blue" p={1} />
+          <Box sx={{ bg: 'blue' }} p={1} />
+        </div>
+        <div>
+          <Box sx={{ bg: 'blue' }} p={1} />
+        </div>
+        <div>
+          <Box sx={{ bg: 'blue' }} p={1} />
+        </div>
+        <div>
+          <Box sx={{ bg: 'blue' }} p={1} />
+        </div>
+        <div>
+          <Box sx={{ bg: 'blue' }} p={1} />
         </div>
       </Grid>
     </Box>

--- a/packages/faency/src/components/Heading.story.tsx
+++ b/packages/faency/src/components/Heading.story.tsx
@@ -9,7 +9,7 @@ storiesOf('Components|Heading', module).add('default', () => (
       <Heading as="p" size={0}>
         Heading 0
       </Heading>
-      <Heading as="p" size={0} fontWeight={500}>
+      <Heading as="p" size={0} sx={{ fontWeight: 500 }}>
         Heading 0
       </Heading>
     </Box>
@@ -18,7 +18,7 @@ storiesOf('Components|Heading', module).add('default', () => (
       <Heading as="p" size={1}>
         Heading 1
       </Heading>
-      <Heading as="p" size={1} fontWeight={500}>
+      <Heading as="p" size={1} sx={{ fontWeight: 500 }}>
         Heading 1
       </Heading>
     </Box>
@@ -27,7 +27,7 @@ storiesOf('Components|Heading', module).add('default', () => (
       <Heading as="p" size={2}>
         Heading 2
       </Heading>
-      <Heading as="p" size={2} fontWeight={500}>
+      <Heading as="p" size={2} sx={{ fontWeight: 500 }}>
         Heading 2
       </Heading>
     </Box>
@@ -36,7 +36,7 @@ storiesOf('Components|Heading', module).add('default', () => (
       <Heading as="p" size={3}>
         Heading 3
       </Heading>
-      <Heading as="p" size={3} fontWeight={500}>
+      <Heading as="p" size={3} sx={{ fontWeight: 500 }}>
         Heading 3
       </Heading>
     </Box>
@@ -45,7 +45,7 @@ storiesOf('Components|Heading', module).add('default', () => (
       <Heading as="p" size={4}>
         Heading 4
       </Heading>
-      <Heading as="p" size={4} fontWeight={500}>
+      <Heading as="p" size={4} sx={{ fontWeight: 500 }}>
         Heading 4
       </Heading>
     </Box>
@@ -54,7 +54,7 @@ storiesOf('Components|Heading', module).add('default', () => (
       <Heading as="p" size={5}>
         Heading 5
       </Heading>
-      <Heading as="p" size={5} fontWeight={500}>
+      <Heading as="p" size={5} sx={{ fontWeight: 500 }}>
         Heading 5
       </Heading>
     </Box>
@@ -65,7 +65,7 @@ storiesOf('Components|Heading', module).add('default', () => (
           Close the gap Close the gap Close the gap Close the gap
         </Heading>
       </Box>
-      <Heading fontWeight={500} mb="3" as="h2">
+      <Heading sx={{ fontWeight: 500 }} mb="3" as="h2">
         Bold
       </Heading>
     </Box>

--- a/packages/faency/src/components/Input.story.tsx
+++ b/packages/faency/src/components/Input.story.tsx
@@ -7,16 +7,16 @@ import { Input } from './Input'
 import { theme } from '../theme'
 
 storiesOf('Components|Input', module).add('default', () => (
-  <Box maxWidth="300px">
+  <Box sx={{ maxWidth: '300px' }}>
     <Box mb="4">
       <Input placeholder="Normal input" />
     </Box>
 
-    <Box mb="4" position="relative">
+    <Box mb="4" sx={{ position: 'relative' }}>
       <Input placeholder="input with icon on the right" type="email" paddingRight={5} />
 
-      <Box position="absolute" height="100%" top={0} right={1} color="grays.4" style={{ pointerEvents: 'none' }}>
-        <Flex alignItems="center" height="100%">
+      <Box sx={{ position: 'absolute', height: '100%', top: 0, right: 1, color: 'grays.4', pointerEvents: 'none' }}>
+        <Flex sx={{ alignItems: 'center', height: '100%' }}>
           <Icon name="search" size="large" fill={theme.colors.grays[5]} />
         </Flex>
       </Box>
@@ -26,11 +26,11 @@ storiesOf('Components|Input', module).add('default', () => (
       <Input size={1} placeholder="size 1 input" />
     </Box>
 
-    <Box mb="4" position="relative">
+    <Box mb="4" sx={{ position: 'relative' }}>
       <Input size={1} placeholder="size 1 input with icon" type="text" paddingLeft={5} />
 
-      <Box position="absolute" height="100%" top={0} left={1} color="grays.4" style={{ pointerEvents: 'none' }}>
-        <Flex alignItems="center" height="100%">
+      <Box sx={{ position: 'absolute', height: '100%', top: 0, left: 1, color: 'grays.4', pointerEvents: 'none' }}>
+        <Flex sx={{ alignItems: 'center', height: '100%' }}>
           <Icon name="search" size="large" fill={theme.colors.grays[5]} />
         </Flex>
       </Box>

--- a/packages/faency/src/components/Menu.story.tsx
+++ b/packages/faency/src/components/Menu.story.tsx
@@ -18,9 +18,9 @@ storiesOf('Components|Menu', module).add('default', () => {
 
   return (
     <>
-      <Box mb="4" height="360px">
+      <Box mb="4" sx={{ height: '360px' }}>
         <div ref={targetRef} />
-        <Menu isOpen buttonRef={targetRef} unstable__disableLock>
+        <Menu isOpen buttonRef={targetRef} anchorPoint={{ x: 0, y: 0 }}>
           <MenuItem label="Simple item one" />
           <MenuItem label="Simple item two" />
           <MenuItem label="Simple item three" />

--- a/packages/faency/src/components/Nav/Nav.story.tsx
+++ b/packages/faency/src/components/Nav/Nav.story.tsx
@@ -33,24 +33,24 @@ storiesOf('Components|Nav', module).add('default', () => (
             <NavGroup variant="right">
               <NavItem variant="active">Documentation</NavItem>
               <NavItem>
-                <Text size={2} textColor="grays.5" fontWeight={600}>
+                <Text size={2} sx={{ color: 'grays.5', fontWeight: 600 }}>
                   Github
                 </Text>
               </NavItem>
             </NavGroup>
             <NavGroup variant="left">
               <NavItem>
-                <Text size={2} textColor="grays.5" fontWeight={600}>
+                <Text size={2} sx={{ color: 'grays.5', fontWeight: 600 }}>
                   Box
                 </Text>
               </NavItem>
               <NavItem variant="active">
-                <Text size={2} textColor="white" fontWeight={600}>
+                <Text size={2} sx={{ color: 'grays.5', fontWeight: 600 }}>
                   Layout
                 </Text>
               </NavItem>
               <NavItem>
-                <Text size={2} textColor="grays.5" fontWeight={600}>
+                <Text size={2} sx={{ color: 'grays.5', fontWeight: 600 }}>
                   Button
                 </Text>
               </NavItem>
@@ -63,12 +63,12 @@ storiesOf('Components|Nav', module).add('default', () => (
       <Nav>
         <NavGroup variant="right">
           <NavItem variant="active">
-            <Text size={2} textColor="white" fontWeight={600}>
+            <Text size={2} sx={{ color: 'white', fontWeight: 600 }}>
               Documentation
             </Text>
           </NavItem>
           <NavItem>
-            <Text size={2} textColor="grays.5" fontWeight={600}>
+            <Text size={2} sx={{ color: 'grays.5', fontWeight: 600 }}>
               Github
             </Text>
           </NavItem>
@@ -79,17 +79,17 @@ storiesOf('Components|Nav', module).add('default', () => (
       <Nav>
         <NavGroup variant="left">
           <NavItem>
-            <Text size={2} textColor="grays.5" fontWeight={600}>
+            <Text size={2} sx={{ color: 'grays.5', fontWeight: 600 }}>
               Box
             </Text>
           </NavItem>
           <NavItem variant="active">
-            <Text size={2} textColor="white" fontWeight={600}>
+            <Text size={2} sx={{ color: 'white', fontWeight: 600 }}>
               Layout
             </Text>
           </NavItem>
           <NavItem>
-            <Text size={2} textColor="grays.5" fontWeight={600}>
+            <Text size={2} sx={{ color: 'grays.5', fontWeight: 600 }}>
               Button
             </Text>
           </NavItem>

--- a/packages/faency/src/components/Nav/Nav.tsx
+++ b/packages/faency/src/components/Nav/Nav.tsx
@@ -144,7 +144,7 @@ export const NavGroups = React.forwardRef<HTMLDivElement, NavGroupsProps>(({ chi
   const uuid = uuidv4()
 
   return (
-    <Flex flex={1} {...props} ref={forwardedRef}>
+    <Flex sx={{ flex: 1 }} {...props} ref={forwardedRef}>
       <MenuButton uuid={uuid} />
       <MenuIcon uuid={uuid} />
       <Menu>{children}</Menu>

--- a/packages/faency/src/components/Radio.story.tsx
+++ b/packages/faency/src/components/Radio.story.tsx
@@ -6,7 +6,7 @@ import { Text } from './Text'
 
 storiesOf('Components|Radio', module).add('default', () => (
   <>
-    <Flex flexDirection="column" mb={2}>
+    <Flex sx={{ flexDirection: 'column' }} mb={2}>
       <label>
         <Radio name="direction" />
         <Text ml={1}>Up</Text>

--- a/packages/faency/src/components/SubNav.story.tsx
+++ b/packages/faency/src/components/SubNav.story.tsx
@@ -16,7 +16,7 @@ storiesOf('Components|SubNav', module).add('default', () => (
           This is a button
         </SubNavItem>
         <SubNavItem>
-          <Text size={2} textColor="grays.5">
+          <Text size={2} sx={{ color: 'grays.5' }}>
             Defaults to Button
           </Text>
         </SubNavItem>
@@ -28,24 +28,24 @@ storiesOf('Components|SubNav', module).add('default', () => (
         <NavGroup variant="right">
           <NavItem variant="active">Documentation</NavItem>
           <NavItem>
-            <Text size={2} textColor="grays.5" fontWeight={600}>
+            <Text size={2} sx={{ color: 'grays.5', fontWeight: 600 }}>
               Github
             </Text>
           </NavItem>
         </NavGroup>
         <NavGroup variant="left">
           <NavItem>
-            <Text size={2} textColor="grays.5" fontWeight={600}>
+            <Text size={2} sx={{ color: 'grays.5', fontWeight: 600 }}>
               Box
             </Text>
           </NavItem>
           <NavItem variant="active">
-            <Text size={2} textColor="white" fontWeight={600}>
+            <Text size={2} sx={{ color: 'white', fontWeight: 600 }}>
               Layout
             </Text>
           </NavItem>
           <NavItem>
-            <Text size={2} textColor="grays.5" fontWeight={600}>
+            <Text size={2} sx={{ color: 'grays.5', fontWeight: 600 }}>
               Button
             </Text>
           </NavItem>
@@ -59,7 +59,7 @@ storiesOf('Components|SubNav', module).add('default', () => (
           This is a button
         </SubNavItem>
         <SubNavItem>
-          <Text size={2} textColor="grays.5">
+          <Text size={2} sx={{ color: 'grays.5' }}>
             Defaults to Button
           </Text>
         </SubNavItem>

--- a/packages/faency/src/components/Table.story.tsx
+++ b/packages/faency/src/components/Table.story.tsx
@@ -5,7 +5,7 @@ import { Table, Thead, Tbody, Tfoot, Tr, Th, Td } from './Table'
 
 storiesOf('Components|Table', module).add('default', () => (
   <>
-    <Box maxWidth="300px" mb={4}>
+    <Box sx={{ maxWidth: '300px' }} mb={4}>
       <Table>
         <Thead>
           <Tr>
@@ -37,7 +37,7 @@ storiesOf('Components|Table', module).add('default', () => (
       </Table>
     </Box>
 
-    <Box maxWidth="100%" width="100%" overflow="auto">
+    <Box sx={{ maxWidth: '100%', width: '100%', overflow: 'auto' }}>
       <Table>
         <Thead>
           <Tr>

--- a/packages/faency/src/components/Text.story.tsx
+++ b/packages/faency/src/components/Text.story.tsx
@@ -40,38 +40,38 @@ storiesOf('Components|Text', module).add('default', () => (
     </Box>
 
     <Box mb="4">
-      <Text as="p" fontStyle="italic">
+      <Text as="p" sx={{ fontStyle: 'italic' }}>
         Enabling the Cloud.
       </Text>
-      <Text as="p" fontWeight={500}>
+      <Text as="p" sx={{ fontWeight: 500 }}>
         Enabling the Cloud.
       </Text>
     </Box>
 
     <Box mb="4">
       <Text as="p">We are Containous</Text>
-      <Text as="p" textColor="blue">
+      <Text as="p" sx={{ color: 'blue' }}>
         We are Containous
       </Text>
-      <Text as="p" textColor="red">
+      <Text as="p" sx={{ color: 'red' }}>
         We are Containous
       </Text>
-      <Text as="p" textColor="green">
+      <Text as="p" sx={{ color: 'green' }}>
         We are Containous
       </Text>
-      <Text as="p" textColor="gray">
+      <Text as="p" sx={{ color: 'gray' }}>
         We are Containous
       </Text>
     </Box>
 
     <Box mb="4">
-      <Text as="p" textAlign="center" padding="4">
+      <Text as="p" sx={{ textAlign: 'center' }} padding="4">
         We are Containous. We strive to provide the cloud with the most powerful tools to ease the demanding
         infrastructures strain on your IT.
       </Text>
     </Box>
-    <Box mb="4" width={200}>
-      <Text as="p" textAlign="center" padding="4" truncate>
+    <Box mb="4" sx={{ width: 200 }}>
+      <Text as="p" sx={{ textAlign: 'center' }} padding="4" truncate>
         We are Containous. We strive to provide the cloud with the most powerful tools to ease the demanding
         infrastructures strain on your IT.
       </Text>

--- a/packages/faency/src/components/ToggleButton.story.tsx
+++ b/packages/faency/src/components/ToggleButton.story.tsx
@@ -1,19 +1,38 @@
 import React, { useState } from 'react'
 import { storiesOf } from '@storybook/react'
 import { Box } from './Box'
-import { ToggleButtonGroup, ToggleButton } from './ToggleButton'
+import { ToggleButton } from './ToggleButton'
 
 storiesOf('Components|ToggleButton', module).add('default', () => {
   const [value, setValue] = useState('center')
 
   return (
     <>
-      <Box width="135px" my={6}>
-        <ToggleButtonGroup value={value} onChange={(value): void => setValue(value)}>
-          <ToggleButton value="left">Left</ToggleButton>
-          <ToggleButton value="center">Center</ToggleButton>
-          <ToggleButton value="right">Right</ToggleButton>
-        </ToggleButtonGroup>
+      <Box sx={{ width: '135px', my: 6 }}>
+        <ToggleButton
+          onToggle={(): void => {
+            setValue('left')
+          }}
+          isToggled={value === 'left'}
+        >
+          Left
+        </ToggleButton>
+        <ToggleButton
+          onToggle={(): void => {
+            setValue('center')
+          }}
+          isToggled={value === 'left'}
+        >
+          Center
+        </ToggleButton>
+        <ToggleButton
+          onToggle={(): void => {
+            setValue('right')
+          }}
+          isToggled={value === 'right'}
+        >
+          Right
+        </ToggleButton>
       </Box>
     </>
   )

--- a/packages/faency/src/components/ToggleButton.test.tsx
+++ b/packages/faency/src/components/ToggleButton.test.tsx
@@ -1,21 +1,45 @@
 import React, { useState } from 'react'
 import { render } from '@testing-library/react'
-import { ToggleButton, ToggleButtonGroup } from './ToggleButton'
+import { ToggleButton } from './ToggleButton'
 import { ThemeProvider } from 'styled-components'
 import { theme as defaultTheme } from '../theme'
 import { theme as defaultDarkTheme } from '../dark-theme'
+import { Flex } from '../components/Flex'
 
 const Component: React.FC = () => {
   const [value, setValue] = useState<string>('center')
 
   return (
-    <>
-      <ToggleButtonGroup value={value} onChange={(value: any): void => setValue(value)}>
-        <ToggleButton value="left">Left</ToggleButton>
-        <ToggleButton value="center">Center</ToggleButton>
-        <ToggleButton value="right">Right</ToggleButton>
-      </ToggleButtonGroup>
-    </>
+    <Flex>
+      {value}
+      <ToggleButton
+        onToggle={(): void => {
+          console.log('setValue left')
+          setValue('left')
+        }}
+        isToggled={value === 'left'}
+      >
+        Left
+      </ToggleButton>
+      <ToggleButton
+        onToggle={(): void => {
+          console.log('setValue center')
+          setValue('center')
+        }}
+        isToggled={value === 'center'}
+      >
+        Center
+      </ToggleButton>
+      <ToggleButton
+        onToggle={(): void => {
+          console.log('setValue right')
+          setValue('right')
+        }}
+        isToggled={value === 'right'}
+      >
+        Right
+      </ToggleButton>
+    </Flex>
   )
 }
 

--- a/packages/faency/src/components/ToggleButton.tsx
+++ b/packages/faency/src/components/ToggleButton.tsx
@@ -1,22 +1,25 @@
 import React, { useContext } from 'react'
 import { ThemeContext } from 'styled-components'
 import {
-  ToggleButtonGroup as ToggleButtonGroupPrimitive,
-  ToggleButtonGroupProps as ToggleButtonGroupPrimitiveProps,
+  ToggleButton as ToggleButtonPrimitive,
+  ToggleButtonProps as ToggleButtonPrimitiveProps,
 } from '@modulz/primitives'
 
-export { ToggleButton } from '@modulz/primitives'
+type Size = 0 | 1
+type Variant = 'normal' | 'fade'
 
-export type ToggleButtonGroupProps<T> = ToggleButtonGroupPrimitiveProps<T>
+export type ToggleButtonProps = ToggleButtonPrimitiveProps & {
+  size?: Size
+  variant?: Variant
+}
 
-export const ToggleButtonGroup = <T extends string | string[] | null>(
-  props: ToggleButtonGroupProps<T>,
-): JSX.Element => {
+export const ToggleButton = React.forwardRef<HTMLButtonElement, ToggleButtonProps>((props, forwardedRef) => {
   const themeContext = useContext(ThemeContext)
 
   return (
-    <ToggleButtonGroupPrimitive
+    <ToggleButtonPrimitive
       {...props}
+      ref={forwardedRef}
       styleConfig={{
         base: {
           button: {
@@ -46,4 +49,11 @@ export const ToggleButtonGroup = <T extends string | string[] | null>(
       }}
     />
   )
+})
+
+ToggleButton.displayName = 'ToggleButton'
+
+ToggleButton.defaultProps = {
+  size: 1,
+  variant: 'normal',
 }

--- a/packages/faency/src/components/Tooltip/Tooltip.story.tsx
+++ b/packages/faency/src/components/Tooltip/Tooltip.story.tsx
@@ -34,27 +34,27 @@ storiesOf('Components|Tooltip', module).add('default', () => (
     </Box>
     <Box mb="6">
       <Tooltip label="default tooltip">
-        <Box width={120} height={120} bg="blue" />
+        <Box sx={{ width: 120, height: 120, bg: 'blue' }} />
       </Tooltip>
     </Box>
     <Box mb="6">
       <Tooltip label="tooltip left" preferredAlignment="left">
-        <Box width={120} height={120} bg="blue" />
+        <Box sx={{ width: 120, height: 120, bg: 'blue' }} />
       </Tooltip>
     </Box>
     <Box mb="6">
       <Tooltip label="tooltip right" preferredAlignment="right">
-        <Box width={120} height={120} bg="blue" />
+        <Box sx={{ width: 120, height: 120, bg: 'blue' }} />
       </Tooltip>
     </Box>
     <Box mb="6">
       <Tooltip label="tooltip right but too long" preferredAlignment="right">
-        <Box width={120} height={120} bg="blue" />
+        <Box sx={{ width: 120, height: 120, bg: 'blue' }} />
       </Tooltip>
     </Box>
-    <Flex mb="6" justifyContent="flex-end">
+    <Flex mb="6" sx={{ justifyContent: 'flex-end' }}>
       <Tooltip label="tooltip left but too long" preferredAlignment="left">
-        <Box width={120} height={120} bg="blue" />
+        <Box sx={{ width: 120, height: 120, bg: 'blue' }} />
       </Tooltip>
     </Flex>
 

--- a/packages/faency/src/components/Tooltip/Tooltip.tsx
+++ b/packages/faency/src/components/Tooltip/Tooltip.tsx
@@ -65,7 +65,7 @@ export const Tooltip: React.FC<TooltipProps> = props => {
           preferredAlignment={props.preferredAlignment}
         >
           <>
-            <BoxPrimitive bg="dark" textColor="white" borderRadius={2} p="1">
+            <BoxPrimitive sx={{ backgroundColor: 'dark', color: 'white', borderRadius: 2 }} p="1">
               {props.label} {renderAction()}
             </BoxPrimitive>
           </>

--- a/packages/faency/src/index.ts
+++ b/packages/faency/src/index.ts
@@ -55,7 +55,7 @@ export { SubNav, SubNavItem, SubNavItemProps } from './components/SubNav'
 export { Switch, SwitchProps } from './components/Switch'
 export { Table, Thead, Tbody, Tfoot, Tr, Th, Td } from './components/Table'
 export { Text, TextProps } from './components/Text'
-export { ToggleButtonGroup, ToggleButton, ToggleButtonGroupProps } from './components/ToggleButton'
+export { ToggleButton, ToggleButtonProps } from './components/ToggleButton'
 export { Tooltip, TooltipProps } from './components/Tooltip'
 
 export { theme } from './theme'

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "website",
-  "private": false,
+  "private": true,
   "repository": {
     "type": "git",
     "url": "https://github.com/containous/faency"
@@ -19,7 +19,7 @@
     "serve": "gatsby serve"
   },
   "dependencies": {
-    "@containous/faency": "^0.5.0",
+    "@containous/faency": "0.5.0",
     "@mdx-js/mdx": "^1.5.5",
     "@mdx-js/react": "^1.5.5",
     "babel-plugin-styled-components": "^1.10.7",

--- a/packages/website/src/App.js
+++ b/packages/website/src/App.js
@@ -34,7 +34,7 @@ function App({ element, props: appProps }) {
     }
     query {
       pinned: allMdx(
-        sort: { order: ASC, fields: [frontmatter___title] }
+        sort: { order: ASC, fields: [frontmatter___order] }
         filter: { frontmatter: { pinned: { ne: null } } }
       ) {
         ...mdxContent
@@ -57,26 +57,29 @@ function App({ element, props: appProps }) {
         return (
           <>
             <Box
-              position={['static', 'fixed']}
-              width={['100%', 200, 250]}
-              height={['auto', '100vh']}
-              overflow={['auto', 'scroll']}
               pb={[0, 8]}
-              borderRight={[0, '1px solid']}
-              borderBottom={['1px solid', 0]}
-              borderColor={[theme.colors.grays[3], theme.colors.grays[3]]}
-              style={{ WebkitOverflowScrolling: 'touch', overflowX: 'hidden' }}
-              backgroundColor={darkMode.value ? '#121826' : 'white'}
+              sx={{
+                position: ['static', 'fixed'],
+                width: ['100%', 200, 250],
+                height: ['auto', '100vh'],
+                overflow: ['auto', 'scroll'],
+                borderRight: [0, '1px solid'],
+                borderBottom: ['1px solid', 0],
+                borderColor: [theme.colors.grays[3], theme.colors.grays[3]],
+                WebkitOverflowScrolling: 'touch',
+                overflowX: 'hidden',
+                bg: darkMode.value ? '#121826' : 'white',
+              }}
             >
               <Box pt={[0, '1em']} px={16}>
-                <Flex alignItems="center">
+                <Flex sx={{ alignItems: 'center' }}>
                   <Box>
                     <img src={darkMode.value ? whiteLogo : logo} alt="Containous Logo" height="35px" />
                   </Box>
                   <Chip ml={1} variant="blue">
                     v{pkg.version}
                   </Chip>
-                  <Box ml="auto" display={['block', 'none']}>
+                  <Box ml="auto" sx={{ display: ['block', 'none'] }}>
                     <Button size={1} variant={navOpen ? 'active' : undefined} onClick={() => setNavOpen(!navOpen)}>
                       <MenuToggle isOpen={navOpen} />
                     </Button>
@@ -84,8 +87,8 @@ function App({ element, props: appProps }) {
                 </Flex>
               </Box>
 
-              <Box display={[navOpen ? 'block' : 'none', 'block']}>
-                <Divider style={{ marginTop: navOpen ? 0 : '1em' }} />
+              <Box sx={{ display: [navOpen ? 'block' : 'none', 'block'] }}>
+                <Divider marginTop={navOpen ? 0 : '1em'} />
                 <List>
                   <Heading size={1} my={10} mx={16}>
                     Overview
@@ -137,7 +140,7 @@ function App({ element, props: appProps }) {
 
                 <Divider />
 
-                <Box px={16} mt={3} minHeight={4}>
+                <Box px={16} mt={3} sx={{ minHeight: 4 }}>
                   <Text size={2}>
                     Powered by{' '}
                     <Link href="https://containo.us" title="Containous">
@@ -145,7 +148,7 @@ function App({ element, props: appProps }) {
                     </Link>
                   </Text>
                 </Box>
-                <Box px={16} mb={2} minHeight={4}>
+                <Box px={16} mb={2} sx={{ minHeight: 4 }}>
                   <Text size={2}>
                     Highly inspired by{' '}
                     <Link href="https://radix.modulz.app/" title="Radix Design System">
@@ -160,10 +163,12 @@ function App({ element, props: appProps }) {
               pt={8}
               pb={9}
               marginLeft={[0, 200, 250]}
-              maxWidth={['100%']}
-              minHeight={['100vh']}
-              display={[navOpen ? 'none' : 'block', 'block']}
-              backgroundColor="bg"
+              sx={{
+                bg: 'bg',
+                maxWidth: ['100%'],
+                minHeight: ['100vh'],
+                display: [navOpen ? 'none' : 'block', 'block'],
+              }}
             >
               <Container size={1}>{element}</Container>
             </Box>

--- a/packages/website/src/components/APISection.js
+++ b/packages/website/src/components/APISection.js
@@ -1,0 +1,142 @@
+import React from 'react'
+import { Heading as FaencyHeading, Text, code, Table, Thead, Tbody, Tr, Th, Td } from '@containous/faency'
+
+export function APISection() {
+  return (
+    <>
+      <Heading>Props</Heading>
+      <Text size={3} color="gray.4" pb={4}>
+        All components include the following props.
+      </Text>
+
+      <Table mb={4}>
+        <Thead>
+          <Tr>
+            <Th>Name</Th>
+            <Th>Type</Th>
+            <Th>Description</Th>
+          </Tr>
+        </Thead>
+        <Tbody>
+          <Tr>
+            <Td>
+              <code variant="fade">sx</code>
+            </Td>
+            <Td>Object</Td>
+            <Td>Theme-aware styles</Td>
+          </Tr>
+          <Tr>
+            <Td>
+              <code variant="fade">variant</code>
+            </Td>
+            <Td>String</Td>
+            <Td>Applies a variant, if available</Td>
+          </Tr>
+        </Tbody>
+      </Table>
+
+      <Heading>Style Props</Heading>
+      <Text size={3} color="gray.4">
+        All components include the following style props.
+      </Text>
+
+      <Table mb={4}>
+        <Thead>
+          <Tr>
+            <Th>Name</Th>
+
+            <Th>Description</Th>
+          </Tr>
+        </Thead>
+        <Tbody>
+          <Tr>
+            <Td>
+              <code variant="fade">margin</code>,<code variant="fade">m</code>
+            </Td>
+            <Td>Margin</Td>
+          </Tr>
+          <Tr>
+            <Td>
+              <code variant="fade">marginTop</code>,<code variant="fade">mt</code>
+            </Td>
+            <Td>Margin top</Td>
+          </Tr>
+          <Tr>
+            <Td>
+              <code variant="fade">marginRight</code>,<code variant="fade">mr</code>
+            </Td>
+            <Td>Margin right</Td>
+          </Tr>
+          <Tr>
+            <Td>
+              <code variant="fade">marginBottom</code>,<code variant="fade">mb</code>
+            </Td>
+            <Td>Margin bottom</Td>
+          </Tr>
+          <Tr>
+            <Td>
+              <code variant="fade">marginLeft</code>,<code variant="fade">ml</code>
+            </Td>
+            <Td>Margin left</Td>
+          </Tr>
+          <Tr>
+            <Td>
+              <code variant="fade">marginX</code>,<code variant="fade">mx</code>
+            </Td>
+            <Td>Margin horizontal</Td>
+          </Tr>
+          <Tr>
+            <Td>
+              <code variant="fade">marginY</code>,<code variant="fade">my</code>
+            </Td>
+            <Td>Margin vertical</Td>
+          </Tr>
+          <Tr>
+            <Td>
+              <code variant="fade">padding</code>,<code variant="fade">p</code>
+            </Td>
+            <Td>Padding</Td>
+          </Tr>
+          <Tr>
+            <Td>
+              <code variant="fade">paddingTop</code>,<code variant="fade">pt</code>
+            </Td>
+            <Td>Padding top</Td>
+          </Tr>
+          <Tr>
+            <Td>
+              <code variant="fade">paddingRight</code>,<code variant="fade">pr</code>
+            </Td>
+            <Td>Padding right</Td>
+          </Tr>
+          <Tr>
+            <Td>
+              <code variant="fade">paddingBottom</code>,<code variant="fade">pb</code>
+            </Td>
+            <Td>Padding bottom</Td>
+          </Tr>
+          <Tr>
+            <Td>
+              <code variant="fade">paddingLeft</code>,<code variant="fade">pl</code>
+            </Td>
+            <Td>Padding left</Td>
+          </Tr>
+          <Tr>
+            <Td>
+              <code variant="fade">paddingX</code>,<code variant="fade">px</code>
+            </Td>
+            <Td>Padding horizontal</Td>
+          </Tr>
+          <Tr>
+            <Td>
+              <code variant="fade">paddingY</code>,<code variant="fade">py</code>
+            </Td>
+            <Td>Padding vertical</Td>
+          </Tr>
+        </Tbody>
+      </Table>
+    </>
+  )
+}
+
+const Heading = props => <FaencyHeading as="h2" weight="medium" size={2} mt={8} mb={4} {...props} />

--- a/packages/website/src/components/Container.js
+++ b/packages/website/src/components/Container.js
@@ -4,7 +4,7 @@ import { Box } from '@containous/faency'
 
 function Container({ children, ...props }) {
   return (
-    <Box px={25} mx="auto" fleGrow={1} flexShrink={1} flexBasis="0%" maxWidth="55rem" {...props}>
+    <Box px={25} mx="auto" sx={{ flexGrow: 1, flexShrink: 1, flexBasis: '0%', maxWidth: '55rem' }} {...props}>
       {children}
     </Box>
   )

--- a/packages/website/src/components/List.js
+++ b/packages/website/src/components/List.js
@@ -4,7 +4,7 @@ import { Flex } from '@containous/faency'
 
 function List({ children, ...props }) {
   return (
-    <Flex flexDirection="column" py={2} {...props}>
+    <Flex sx={{ flexDirection: 'column' }} py={2} {...props}>
       {children}
     </Flex>
   )

--- a/packages/website/src/components/NavItem.js
+++ b/packages/website/src/components/NavItem.js
@@ -12,7 +12,7 @@ function NavItem({ children, isExternal, active, ...props }) {
     <Button as={Link} {...props} variant="secondary" px={5} minHeight={6} style={{ justifyContent: 'flex-start' }}>
       <Text
         size={2}
-        textColor={active ? 'blue' : darkMode.value ? theme.colors.grays[4] : undefined}
+        sx={{ color: active ? 'blue' : darkMode.value ? theme.colors.grays[4] : undefined }}
         mr={isExternal ? 1 : 0}
       >
         {children}

--- a/packages/website/src/components/PropRender.js
+++ b/packages/website/src/components/PropRender.js
@@ -18,28 +18,16 @@ const isColor = (value, themeContext) => {
   }
 }
 
-const renderString = children => (
-  <Text fontWeight={700} textColor="green">
-    &quot;{children}&quot;
-  </Text>
-)
+const renderString = children => <Text sx={{ fontWeight: 700, color: 'green' }}>&quot;{children}&quot;</Text>
 
-const renderNumber = children => (
-  <Text fontWeight={700} textColor="blue">
-    {children}
-  </Text>
-)
+const renderNumber = children => <Text sx={{ fontWeight: 700, color: 'blue' }}>{children}</Text>
 
-const renderBoolean = children => (
-  <Text fontWeight={700} textColor="lightBlue">
-    {children}
-  </Text>
-)
+const renderBoolean = children => <Text sx={{ fontWeight: 700, color: 'lightblue' }}>{children}</Text>
 
 const renderColor = children => (
-  <Flex alignItems="center" style={{ display: 'inline-flex' }}>
-    <Box bg={children} height="8px" width="8px" mr="4px" boxShadow="0 0 0 1px black" />
-    <Text fontWeight={700}>{children}</Text>
+  <Flex sx={{ display: 'inline-flex', alignItems: 'center' }}>
+    <Box sx={{ backgroundColor: children, height: '8px', width: '8px', boxShadow: '0 0 0 1px black' }} mr="4px" />
+    <Text sx={{ fontWeight: 700 }}>{children}</Text>
   </Flex>
 )
 

--- a/packages/website/src/components/PropsTable.js
+++ b/packages/website/src/components/PropsTable.js
@@ -1,18 +1,26 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Box, Chip, Table, Thead, Tr, Th, Tbody, Td, Text, Heading } from '@containous/faency'
+import { Box, Button, Chip, Table, Thead, Tr, Th, Tbody, Td, Text, Heading } from '@containous/faency'
+import { Link as GatsbyLink } from 'gatsby'
 import { PropRender } from './PropRender'
 
 export function PropsTable({ data, title = 'Props' }) {
   const hasProps = Object.keys(data).length > 0
 
   return (
-    <Box mt={8} mb={7} overflow={['scroll', 'visible']} style={{ WebkitOverflowScrolling: 'touch' }}>
+    <Box
+      mt={8}
+      mb={7}
+      sx={{
+        overflow: ['scroll', 'visible'],
+        WebkitOverflowScrolling: 'touch',
+      }}
+    >
       <Heading as="h3" size={3} mt={45} mb={25}>
         {title}
       </Heading>
-      {hasProps ? (
-        <Box minWidth={['540px', '0']}>
+      {hasProps && (
+        <Box sx={{ minWidth: ['540px', '0'] }}>
           <Table>
             <Thead>
               <Tr>
@@ -50,9 +58,14 @@ export function PropsTable({ data, title = 'Props' }) {
             </Tbody>
           </Table>
         </Box>
-      ) : (
-        <Text as="p">No props</Text>
       )}
+      <Text as="p" size={3} mt={6} mb={4}>
+        This component supports all{' '}
+        <Button as={GatsbyLink} to="/docs/api" p={0}>
+          common props
+        </Button>
+        .
+      </Text>
     </Box>
   )
 }

--- a/packages/website/src/components/ThemeSection.js
+++ b/packages/website/src/components/ThemeSection.js
@@ -37,7 +37,7 @@ export function ThemeSection() {
 
       <Heading my={4}>Line heights</Heading>
       {Object.entries(theme.lineHeights).map(([key, value]) => (
-        <Text size={8} mr={4} fontWeight={500} key={key}>
+        <Text size={8} mr={4} weigth={500} key={key}>
           {removeUnit(value)}
         </Text>
       ))}
@@ -46,7 +46,7 @@ export function ThemeSection() {
 
       <Heading my={4}>Space scale</Heading>
       {Object.entries(theme.space).map(([key, value]) => (
-        <Text size={8} mr={4} fontWeight={500} key={key}>
+        <Text size={8} mr={4} weigth={500} key={key}>
           {removeUnit(value)}
         </Text>
       ))}
@@ -55,7 +55,7 @@ export function ThemeSection() {
 
       <Heading my={4}>Size scale</Heading>
       {Object.entries(theme.sizes).map(([key, value]) => (
-        <Text size={8} mr={4} fontWeight={500} key={key}>
+        <Text size={8} mr={4} weigth={500} key={key}>
           {removeUnit(value)}
         </Text>
       ))}
@@ -64,7 +64,7 @@ export function ThemeSection() {
 
       <Heading my={4}>Radii scale</Heading>
       {Object.entries(theme.radii).map(([key, value]) => (
-        <Text size={8} mr={4} fontWeight={500} key={key}>
+        <Text size={8} mr={4} weigth={500} key={key}>
           {typeof value === 'string' ? removeUnit(value) : value}
         </Text>
       ))}
@@ -86,10 +86,10 @@ const ColorCard = ({ color, name, props }) => (
   <Box {...props}>
     <Box>
       <Box
-        bg={color}
-        width={50}
-        height={50}
-        css={{
+        sx={{
+          width: 50,
+          height: 50,
+          bg: color,
           borderRadius: 'inherit',
           '& > *': {
             borderRadius: 'inherit',
@@ -120,5 +120,5 @@ const Heading = props => <FaencyHeading as="h2" size={2} mt={8} mb={4} {...props
 const Subheading = props => <FaencyHeading as="h3" size={1} mt={6} mb={4} {...props} />
 
 const SectionTitle = props => (
-  <Text size={2} marginY={0} textColor="gray700" style={{ textTransform: 'capitalize' }} {...props} />
+  <Text size={2} marginY={0} sx={{ textColor: 'gray700', textTransform: 'capitalize' }} {...props} />
 )

--- a/packages/website/src/docs/api.mdx
+++ b/packages/website/src/docs/api.mdx
@@ -1,0 +1,8 @@
+---
+title: API
+pinned: 'true'
+description: These are the common props used by all components.
+order: 1
+---
+
+<APISection />

--- a/packages/website/src/docs/avatar.mdx
+++ b/packages/website/src/docs/avatar.mdx
@@ -24,23 +24,10 @@ description: Useful for presenting profile images and initials.
     },
     variant: {
       type: 'light | dark',
-      description: 'The variant to use, it changes the colors and hover effect. The default value is the current theme.'
-    }
+      description:
+        'The variant to use, it changes the colors and hover effect. The default value is the current theme.',
+    },
   }}
-/>
-<SystemProps
-  props={[
-    'backgroundColor',
-    'margin',
-    'marginTop',
-    'marginRight',
-    'marginBottom',
-    'marginLeft',
-    'marginX',
-    'marginY',
-    'width',
-    'height',
-  ]}
 />
 
 ## Examples
@@ -55,10 +42,10 @@ description: Useful for presenting profile images and initials.
 
 ```js live
 <Avatar src="">
-  <Text textColor="white" marginBottom={1}>
+  <Text sx={{ color: 'white' }} marginBottom={1}>
     K
   </Text>
-  <Text textColor="white" marginTop={1}>
+  <Text sx={{ color: 'white' }} marginTop={1}>
     S
   </Text>
 </Avatar>
@@ -72,8 +59,8 @@ function AlternativeVariant() {
   const isDarkMode = darkMode.value
 
   return (
-    <Box backgroundColor="dark" padding={2}>
-      <Avatar src={getValidImageUrl()} backgroundColor="purple" variant={isDarkMode ? 'light' : 'dark'}>
+    <Box sx={{ bg: 'dark' }} p={2}>
+      <Avatar src={getValidImageUrl()} sx={{ bg: 'purple' }} variant={isDarkMode ? 'light' : 'dark'}>
         KS
       </Avatar>
     </Box>
@@ -89,7 +76,7 @@ function AnotherAlternativeVariant() {
   const isDarkMode = darkMode.value
 
   return (
-    <Box backgroundColor="dark" padding={2}>
+    <Box sx={{ bg: 'dark' }} p={2}>
       <Avatar src="" variant={isDarkMode ? 'light' : 'dark'}>
         KS
       </Avatar>

--- a/packages/website/src/docs/box.mdx
+++ b/packages/website/src/docs/box.mdx
@@ -5,7 +5,7 @@ description: A primitive useful for layout.
 ---
 
 ```js live
-<Box p={6} textColor="white" bg="blue" borderRadius={1}>
+<Box p={6} sx={{ bg: 'blue', color: 'white', borderRadius: 1 }}>
   Box
 </Box>
 ```
@@ -17,28 +17,4 @@ description: A primitive useful for layout.
       description: 'The content to render',
     },
   }}
-/>
-<SystemProps
-  props={[
-    'border',
-    'borderRadius',
-    'boxShadow',
-    'backgroundColor',
-    'display',
-    'opacity',
-    'height',
-    'justifySelf',
-    'margin',
-    'maxWidth',
-    'maxHeight',
-    'minHeight',
-    'minWidth',
-    'overflow',
-    'padding',
-    'positionSet',
-    'textAlign',
-    'textColor',
-    'width',
-    'flexItemSet',
-  ]}
 />

--- a/packages/website/src/docs/button.mdx
+++ b/packages/website/src/docs/button.mdx
@@ -32,8 +32,6 @@ description: Useful to communicate actions to your users.
   }}
 />
 
-<SystemProps props={['margin']} />
-
 ## Examples
 
 ### Colors

--- a/packages/website/src/docs/card-link.mdx
+++ b/packages/website/src/docs/card-link.mdx
@@ -5,7 +5,7 @@ description: Useful to group information about a subject and link it to another 
 ---
 
 ```js live
-<CardLink maxWidth={275} href="" target="">
+<CardLink sx={{ maxWidth: 275 }} href="" target="">
   <Heading size={1}>Card heading</Heading>
   <Text as="p" mt={2} mb={4} size={3}>
     Card content
@@ -26,7 +26,6 @@ description: Useful to group information about a subject and link it to another 
     },
   }}
 />
-<SystemProps props={['href', 'target', 'onClick', 'textColor', 'backgroundColor', 'margin', 'padding', 'width', 'maxWidth']} />
 
 ## Examples
 
@@ -35,7 +34,7 @@ description: Useful to group information about a subject and link it to another 
 There are 3 variants to choose from.
 
 ```js live
-<CardLink maxWidth={275} variant="border" href="" target="">
+<CardLink sx={{ maxWidth: 275 }} variant="border" href="" target="">
   <Heading size={1}>Bordered card (default)</Heading>
   <Text as="p" mt={2} mb={4} size={3}>
     Card content
@@ -44,7 +43,7 @@ There are 3 variants to choose from.
 ```
 
 ```js live
-<CardLink maxWidth={275} variant="shadow" href="" target="">
+<CardLink sx={{ maxWidth: 275 }} variant="shadow" href="" target="">
   <Heading size={1}>Shadow card</Heading>
   <Text as="p" mt={2} mb={4} size={3}>
     Card content
@@ -53,7 +52,7 @@ There are 3 variants to choose from.
 ```
 
 ```js live
-<CardLink maxWidth={275} variant="ghost" href="" target="">
+<CardLink sx={{ maxWidth: 275 }} variant="ghost" href="" target="">
   <Heading size={1}>Ghost card</Heading>
   <Text as="p" mt={2} mb={4} size={3}>
     Card content

--- a/packages/website/src/docs/card.mdx
+++ b/packages/website/src/docs/card.mdx
@@ -5,7 +5,7 @@ description: Useful to group information and actions about a single subject.
 ---
 
 ```js live
-<Card maxWidth={275}>
+<Card sx={{ maxWidth: 275 }}>
   <Heading size={1}>Card heading</Heading>
   <Text as="p" mt={2} mb={4} size={3}>
     Card copy
@@ -27,7 +27,6 @@ description: Useful to group information and actions about a single subject.
     },
   }}
 />
-<SystemProps props={['textColor', 'backgroundColor', 'margin', 'padding', 'width', 'maxWidth']} />
 
 ## Examples
 
@@ -36,7 +35,7 @@ description: Useful to group information and actions about a single subject.
 There are 3 variants to choose from.
 
 ```js live
-<Card maxWidth={275} variant="border">
+<Card sx={{ maxWidth: 275 }} variant="border">
   <Heading size={1}>Bordered card (default)</Heading>
   <Text as="p" mt={2} mb={4} size={3}>
     Card copy
@@ -46,7 +45,7 @@ There are 3 variants to choose from.
 ```
 
 ```js live
-<Card maxWidth={275} variant="shadow">
+<Card sx={{ maxWidth: 275 }} variant="shadow">
   <Heading size={1}>Shadow card</Heading>
   <Text as="p" mt={2} mb={4} size={3}>
     Card copy
@@ -56,7 +55,7 @@ There are 3 variants to choose from.
 ```
 
 ```js live
-<Card maxWidth={275} variant="ghost">
+<Card sx={{ maxWidth: 275 }} variant="ghost">
   <Heading size={1}>Ghost card</Heading>
   <Text as="p" mt={2} mb={4} size={3}>
     Card copy

--- a/packages/website/src/docs/checkbox.mdx
+++ b/packages/website/src/docs/checkbox.mdx
@@ -7,5 +7,3 @@ description: Useful for allowing users to select one or more options in a form.
 ```js live
 <Checkbox defaultChecked />
 ```
-
-<SystemProps props={['margin']} />

--- a/packages/website/src/docs/chip.mdx
+++ b/packages/website/src/docs/chip.mdx
@@ -31,9 +31,6 @@ description: Useful to emphasise information to the user, works best with single
     },
   }}
 />
-<SystemProps
-  props={['textColor', 'margin', 'padding', 'fontStyle', 'fontFamily', 'fontWeight', 'textAlign', 'lineHeight']}
-/>
 
 ## Examples
 
@@ -80,7 +77,7 @@ There are 7 colors to choose from.
 When `true` this will truncate your text based on its maximum width.
 
 ```js live
-<Flex mb="2" maxWidth="150px">
+<Flex mb="2" sx={{ maxWidth: 150 }}>
   <Chip truncate title="At Containous, our goal is to make networking boring.">
     At Containous, our goal is to make networking boring.
   </Chip>

--- a/packages/website/src/docs/flex.mdx
+++ b/packages/website/src/docs/flex.mdx
@@ -6,9 +6,9 @@ description: A primitive useful for flexible layouts.
 
 ```js live
 <Flex>
-  <Box flex="1" height={35} bg="blues.6" />
-  <Box flex="1" height={35} bg="blues.6" mx={6} />
-  <Box flex="1" height={35} bg="blues.6" />
+  <Box sx={{ flex: 1, height: 35, bg: 'blues.6' }} />
+  <Box sx={{ flex: 1, height: 35, bg: 'blues.6' }} mx={6} />
+  <Box sx={{ flex: 1, height: 35, bg: 'blues.6' }} />
 </Flex>
 ```
 
@@ -19,30 +19,4 @@ description: A primitive useful for flexible layouts.
       description: 'The content to render',
     },
   }}
-/>
-<SystemProps
-  props={[
-    'flexContainerSet',
-    // everything below is from Box
-    'border',
-    'borderRadius',
-    'boxShadow',
-    'backgroundColor',
-    'display',
-    'opacity',
-    'height',
-    'justifySelf',
-    'margin',
-    'maxWidth',
-    'maxHeight',
-    'minHeight',
-    'minWidth',
-    'overflow',
-    'padding',
-    'positionSet',
-    'textAlign',
-    'textColor',
-    'width',
-    'flexItemSet',
-  ]}
 />

--- a/packages/website/src/docs/getting-started.mdx
+++ b/packages/website/src/docs/getting-started.mdx
@@ -2,6 +2,7 @@
 title: Getting Started
 pinned: 'true'
 description: Faency is the React component library used at Containous.
+order: 0
 ---
 
 ### Installing Faency

--- a/packages/website/src/docs/grid.mdx
+++ b/packages/website/src/docs/grid.mdx
@@ -5,24 +5,24 @@ description: A primitive useful for grid layouts.
 ---
 
 ```js live
-<Grid gridTemplateColumns="repeat(5, 1fr)" gridGap={6}>
+<Grid sx={{ gridTemplateColumns: 'repeat(5, 1fr)', gridGap: 6 }}>
   <div>
-    <Box bg="blue" p={1} />
+    <Box sx={{ bg: 'blue' }} p={1} />
   </div>
   <div>
-    <Box bg="blue" p={1} />
+    <Box sx={{ bg: 'blue' }} p={1} />
   </div>
   <div>
-    <Box bg="blue" p={1} />
+    <Box sx={{ bg: 'blue' }} p={1} />
   </div>
   <div>
-    <Box bg="blue" p={1} />
+    <Box sx={{ bg: 'blue' }} p={1} />
   </div>
   <div>
-    <Box bg="blue" p={1} />
+    <Box sx={{ bg: 'blue' }} p={1} />
   </div>
   <div>
-    <Box bg="blue" p={1} />
+    <Box sx={{ bg: 'blue' }} p={1} />
   </div>
 </Grid>
 ```
@@ -35,4 +35,3 @@ description: A primitive useful for grid layouts.
     },
   }}
 />
-<SystemProps props={['alignContent', 'alignItems', 'gridSet', 'margin', 'padding']} />

--- a/packages/website/src/docs/heading.mdx
+++ b/packages/website/src/docs/heading.mdx
@@ -31,7 +31,6 @@ description: Useful for rendering headlines.
     },
   }}
 />
-<SystemProps props={['textColor', 'margin', 'padding', 'textAlign', 'fontWeight', 'lineHeight']} />
 
 ## Examples
 

--- a/packages/website/src/docs/input.mdx
+++ b/packages/website/src/docs/input.mdx
@@ -27,9 +27,6 @@ description: Useful for allowing users to enter, update and select text.
     },
   }}
 />
-<SystemProps
-  props={['textColor', 'margin', 'padding', 'width', 'maxWidth', 'textAlign']}
-/>
 
 ## Examples
 

--- a/packages/website/src/docs/nav.mdx
+++ b/packages/website/src/docs/nav.mdx
@@ -67,7 +67,7 @@ There are 2 variants to choose from.
 <Nav>
   <NavGroup variant="right">
     <NavItem>
-      <Text size={2} textColor="grays.5" fontWeight={600}>
+      <Text size={2} sx={{ color: 'grays.5', fontWeight: 600 }}>
         Button on the right
       </Text>
     </NavItem>
@@ -79,7 +79,7 @@ There are 2 variants to choose from.
 <Nav>
   <NavGroup variant="left">
     <NavItem>
-      <Text size={2} textColor="grays.5" fontWeight={600}>
+      <Text size={2} sx={{ color: 'grays.5', fontWeight: 600 }}>
         Button on the left (default)
       </Text>
     </NavItem>

--- a/packages/website/src/docs/radio.mdx
+++ b/packages/website/src/docs/radio.mdx
@@ -8,5 +8,3 @@ description: Useful for allowing users to select only one option from a set.
 <Radio name="direction" value="row" defaultChecked mr={1} />
 <Radio name="direction" value="column" />
 ```
-
-<SystemProps props={['margin']} />

--- a/packages/website/src/docs/select.mdx
+++ b/packages/website/src/docs/select.mdx
@@ -34,8 +34,7 @@ description: Useful for allowing users to select only one option from a set.
     },
   }}
 />
-<SystemProps props={['margin', 'width']} />
-<Heading as="h2" size={4} fontWeight={500} mb={2} mt={6} lineHeight={4}>
+<Heading as="h2" size={4} mb={2} mt={6}>
   Option
 </Heading>
 <PropsTable
@@ -50,7 +49,7 @@ description: Useful for allowing users to select only one option from a set.
     },
   }}
 />
-<Heading as="h2" size={4} fontWeight={500} mb={2} mt={6} lineHeight={4}>
+<Heading as="h2" size={4} mb={2} mt={6}>
   OptionGroup
 </Heading>
 <PropsTable

--- a/packages/website/src/docs/skeleton.mdx
+++ b/packages/website/src/docs/skeleton.mdx
@@ -16,7 +16,7 @@ description: Useful for displaying during content loading
   <SkeletonBox width={60} height={60} borderRadius={30} />
 ```
 
-<Heading as="h2" size={4} fontWeight={500} mb={2} mt={6} lineHeight={4}>
+<Heading as="h2" size={4} mb={2} mt={6}>
   SkeletonText
 </Heading>
 <PropsTable
@@ -28,7 +28,7 @@ description: Useful for displaying during content loading
     },
   }}
 />
-<Heading as="h2" size={4} fontWeight={500} mb={2} mt={6} lineHeight={4}>
+<Heading as="h2" size={4} mb={2} mt={6}>
   SkeletonTextGroup
 </Heading>
 <PropsTable
@@ -40,30 +40,6 @@ description: Useful for displaying during content loading
     },
   }}
 />
-<Heading as="h2" size={4} fontWeight={500} mb={2} mt={6} lineHeight={4}>
+<Heading as="h2" size={4} mb={2} mt={6}>
   SkeletonBox
 </Heading>
-<SystemProps
-  props={[
-    'border',
-    'borderRadius',
-    'boxShadow',
-    'backgroundColor',
-    'display',
-    'opacity',
-    'height',
-    'justifySelf',
-    'margin',
-    'maxWidth',
-    'maxHeight',
-    'minHeight',
-    'minWidth',
-    'overflow',
-    'padding',
-    'positionSet',
-    'textAlign',
-    'textColor',
-    'width',
-    'flexItemSet',
-  ]}
-/>

--- a/packages/website/src/docs/subnav.mdx
+++ b/packages/website/src/docs/subnav.mdx
@@ -13,7 +13,7 @@ description: A sub navigation bar
     This is a button
   </SubNavItem>
   <SubNavItem>
-    <Text size={2} textColor="grays.5">
+    <Text size={2} sx={{ color: 'grays.5' }}>
       Defaults to Button
     </Text>
   </SubNavItem>

--- a/packages/website/src/docs/switch.mdx
+++ b/packages/website/src/docs/switch.mdx
@@ -7,5 +7,3 @@ description: Useful for allowing users to toggle boolean options in a form.
 ```js live
 <Switch value="accept" />
 ```
-
-<SystemProps props={['margin']} />

--- a/packages/website/src/docs/text.mdx
+++ b/packages/website/src/docs/text.mdx
@@ -31,9 +31,6 @@ description: A primitive useful for rendering text.
     },
   }}
 />
-<SystemProps
-  props={['textColor', 'margin', 'padding', 'fontStyle', 'fontFamily', 'fontWeight', 'textAlign', 'lineHeight']}
-/>
 
 ## Examples
 

--- a/packages/website/src/docs/theme.mdx
+++ b/packages/website/src/docs/theme.mdx
@@ -2,6 +2,7 @@
 title: Theme
 pinned: 'true'
 description: Here are all of Faency's design system tokens.
+order: 0
 ---
 
 <ThemeSection />

--- a/packages/website/src/docs/toggle-button.mdx
+++ b/packages/website/src/docs/toggle-button.mdx
@@ -4,35 +4,27 @@ component: ToggleButton
 description: Useful for allowing users to select one or more options from a set.
 ---
 
-```js live
-<Box width="135px">
-  <ToggleButtonGroup value="left" onChange={alert}>
-    <ToggleButton value="left">Left</ToggleButton>
-    <ToggleButton value="center">Center</ToggleButton>
-    <ToggleButton value="right">Right</ToggleButton>
-  </ToggleButtonGroup>
-</Box>
+```js live removeFragment
+() => {
+  const [value, setCurrentValue] = React.useState('center')
+
+  return (
+    <Flex sx={{ width: '135px' }}>
+      <ToggleButton value="left" isToggled={value === 'left'} onToggle={() => setCurrentValue('left')}>
+        Left
+      </ToggleButton>
+      <ToggleButton value="center" isToggled={value === 'center'} onToggle={() => setCurrentValue('center')}>
+        Center
+      </ToggleButton>
+      <ToggleButton value="right" isToggled={value === 'right'} onToggle={() => setCurrentValue('right')}>
+        Right
+      </ToggleButton>
+    </Flex>
+  );
+};
 ```
 
 <PropsTable
-  title="ToggleButtonGroup Props"
-  data={{
-    children: {
-      type: 'ReactNode',
-      description: 'The content to render',
-    },
-    value: {
-      type: 'any',
-      description: 'The current selected value',
-    },
-    onChange: {
-      type: 'function',
-      description: 'Callback triggered with the selected ToggleButton value as parameter',
-    },
-  }}
-/>
-<PropsTable
-  title="ToggleButton Props"
   data={{
     children: {
       type: 'ReactNode',

--- a/packages/website/src/templates/doc-page.js
+++ b/packages/website/src/templates/doc-page.js
@@ -11,16 +11,17 @@ import Icon from 'react-eva-icons'
 import { SystemPropsTable } from '../components/SystemPropsTable'
 import { PropsTable } from '../components/PropsTable'
 import { ThemeSection } from '../components/ThemeSection'
+import { APISection } from '../components/APISection'
 import useDarkMode from 'use-dark-mode'
 
 function Prop(props) {
   return (
     <FC.Box mb={3}>
-      <FC.Text as="p" size={2} lineHeight={2} textColor={FC.theme.colors.grays[7]}>
+      <FC.Text as="p" size={2} sx={{ lineHeight: 2, color: FC.theme.colors.grays[7] }}>
         {props.isOptional && 'optional'} <code>{props.children}</code>
       </FC.Text>
       {props.default && (
-        <FC.Text as="p" size={2} lineHeight={2} textColor="gray700">
+        <FC.Text as="p" size={2} sx={{ lineHeight: 2, color: 'gray700' }}>
           default <code>{props.default}</code>
         </FC.Text>
       )}
@@ -60,16 +61,17 @@ export const components = {
     return <FC.Heading {...props} as="h2" size={2} mt={8} mb={26} />
   },
   h3: function H3(props) {
-    return <FC.Heading {...props} as="h3" size={1} mt={7} mb={22} lineHeight={1} />
+    return <FC.Heading {...props} as="h3" size={1} mt={7} mb={22} sx={{ lineHeight: 1 }} />
   },
   h4: function H4(props) {
-    return <FC.Heading {...props} as="h4" fontWeight={500} size={0} mt={6} mb={1} lineHeight={2} />
+    return <FC.Heading {...props} as="h4" weight={500} size={0} mt={6} mb={1} sx={{ lineHeight: 2 }} />
   },
   p: function P(props) {
     return <FC.Text {...props} as="p" size={3} lineHeight={3} />
   },
   Prop,
   ThemeSection,
+  APISection,
   useDarkMode,
   getValidImageUrl: () =>
     'https://images.unsplash.com/photo-1579380287268-aa88d096651c?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=400&q=80',

--- a/packages/website/src/wrapPageElement.js
+++ b/packages/website/src/wrapPageElement.js
@@ -9,13 +9,15 @@ const Wrapper = props => {
   return (
     <FaencyProvider useDarkTheme={darkMode.value}>
       <Flex
-        position={('absolute', 'absolute', 'fixed')}
-        top={[0, 2]}
-        left={['50%', 'inherit']}
-        right={[null, 2]}
-        height={49}
         ml={['-42px', 'inherit']}
-        alignItems="center"
+        sx={{
+          alignItems: 'center',
+          position: ['absolute', 'absolute', 'fixed'],
+          top: [0, 2],
+          left: ['50%', 'inherit'],
+          right: [null, 2],
+          height: 49,
+        }}
       >
         <Text mr={1} onClick={darkMode.toggle} style={{ cursor: 'default' }}>
           Dark Mode {darkMode.value ? 'On' : 'Off'}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2295,30 +2295,29 @@
   resolved "https://registry.yarnpkg.com/@mikaelkristiansson/domready/-/domready-1.0.10.tgz#f6d69866c0857664e70690d7a0bfedb72143adb5"
   integrity sha512-6cDuZeKSCSJ1KvfEQ25Y8OXUjqDJZ+HgUs6dhASWbAX8fxVraTfPsSeRe2bN+4QJDsgUaXaMWBYfRomCr04GGg==
 
-"@modulz/primitives@^0.0.1-14":
-  version "0.0.1-14"
-  resolved "https://registry.yarnpkg.com/@modulz/primitives/-/primitives-0.0.1-14.tgz#59ffb4bf4a16792146a9c4966a108069e630a274"
-  integrity sha512-dvi5P/21NczE/bMvciPY3CKzSuOB/T4v6LFr260yCFxWgAjkWnLsBU280bmaZY+6XCi4Es/9/B2GiknLnyNgtw==
+"@modulz/primitives@^0.0.1-20":
+  version "0.0.1-23"
+  resolved "https://registry.yarnpkg.com/@modulz/primitives/-/primitives-0.0.1-23.tgz#de93e05ea4bcbee76f88512251156fc7138ca7be"
+  integrity sha512-jnsYOeTLRs9lwIgmaByfydxJktz0LWonvH+8gLXFCNd237n3TcDb4pxF80Q/CoXpQaLTugGlnOizeuqc8PCslg==
   dependencies:
-    "@modulz/radix-icons" "^1.0.1"
-    "@modulz/radix-system" "^0.0.1-alpha.11"
+    "@modulz/radix-icons" "2.0.0"
+    "@modulz/radix-system" "0.0.1-alpha.11"
     aria-hidden "^1.1.1"
     body-scroll-lock "^2.6.4"
     focus-options-polyfill "^1.4.0"
     lodash.merge "^4.6.2"
     lodash.omit "^4.5.0"
     lodash.pick "^4.4.0"
-    react-focus-on "^3.3.0"
     react-is "^16.12.0"
     resize-observer-polyfill "^1.5.1"
     tabbable "^4.0.0"
 
-"@modulz/radix-icons@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@modulz/radix-icons/-/radix-icons-1.0.1.tgz#e3543fd76d0d6f4e90dbb6fd2306b326dc1d060d"
-  integrity sha512-9uFfvKO0KfjyoC2M37m4sj6SAIzaTaNDWeYfZNrY2p0anrUtdsKOhtENc/QLccfXPeS7N+M3w2ksmtKXw8HV7Q==
+"@modulz/radix-icons@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@modulz/radix-icons/-/radix-icons-2.0.0.tgz#b179f0328b10d82573b77f2e22825d8647d7033b"
+  integrity sha512-kp7hVMPVaQ2+9r2l6Cg28Huj5z3aBKl1jk7lmqtnnPEJH7vr6p6lS3u2RxMhTGQvg+H1mXJGTKhveG++87RYGQ==
 
-"@modulz/radix-system@^0.0.1-alpha.11":
+"@modulz/radix-system@0.0.1-alpha.11":
   version "0.0.1-alpha.11"
   resolved "https://registry.yarnpkg.com/@modulz/radix-system/-/radix-system-0.0.1-alpha.11.tgz#569d105799618bde45872e13be52e26131ccb978"
   integrity sha512-Cc0WG+dVKx6gCYqQGvq0ENAvyPgiH8Dmq0ktrZuQj2OjS0IRuV2z/uuOQOK+R8cMC8Ju/NLeCLrUKqG21Yuk2g==
@@ -8342,7 +8341,7 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
-focus-lock@^0.6.3, focus-lock@^0.6.6:
+focus-lock@^0.6.3:
   version "0.6.6"
   resolved "https://registry.yarnpkg.com/focus-lock/-/focus-lock-0.6.6.tgz#98119a755a38cfdbeda0280eaa77e307eee850c7"
   integrity sha512-Dx69IXGCq1qsUExWuG+5wkiMqVM/zGx/reXSJSLogECwp3x6KeNQZ+NAetgxEFpnC41rD8U3+jRCW68+LNzdtw==
@@ -15292,7 +15291,7 @@ rc@^1.2.8:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-clientside-effect@^1.2.0, react-clientside-effect@^1.2.2:
+react-clientside-effect@^1.2.0:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/react-clientside-effect/-/react-clientside-effect-1.2.2.tgz#6212fb0e07b204e714581dd51992603d1accc837"
   integrity sha512-nRmoyxeok5PBO6ytPvSjKp9xwXg9xagoTK1mMjwnQxqM9Hd7MNPl+LS1bOSOe+CV2+4fnEquc7H/S8QD3q697A==
@@ -15417,30 +15416,6 @@ react-focus-lock@^1.18.3:
     prop-types "^15.6.2"
     react-clientside-effect "^1.2.0"
 
-react-focus-lock@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/react-focus-lock/-/react-focus-lock-2.2.1.tgz#1d12887416925dc53481914b7cedd39494a3b24a"
-  integrity sha512-47g0xYcCTZccdzKRGufepY8oZ3W1Qg+2hn6u9SHZ0zUB6uz/4K4xJe7yYFNZ1qT6m+2JDm82F6QgKeBTbjW4PQ==
-  dependencies:
-    "@babel/runtime" "^7.0.0"
-    focus-lock "^0.6.6"
-    prop-types "^15.6.2"
-    react-clientside-effect "^1.2.2"
-    use-callback-ref "^1.2.1"
-    use-sidecar "^1.0.1"
-
-react-focus-on@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/react-focus-on/-/react-focus-on-3.3.0.tgz#f6b3630ef61cdb26018b4d47cafca726b0d7aaa5"
-  integrity sha512-Qbgg2A0YwVuY2g3l5yazzTlHrOC6L4a1P2advANQmdXo7xeAokV5RCtk4sqT0ZoW81LU8IAJCsYzqIdXBBclGg==
-  dependencies:
-    aria-hidden "^1.1.1"
-    react-focus-lock "^2.2.1"
-    react-remove-scroll "^2.2.0"
-    react-style-singleton "^2.0.0"
-    use-callback-ref "^1.2.1"
-    use-sidecar "^1.0.1"
-
 react-helmet-async@^1.0.2:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/react-helmet-async/-/react-helmet-async-1.0.4.tgz#079ef10b7fefcaee6240fefd150711e62463cc97"
@@ -15538,25 +15513,6 @@ react-reconciler@^0.24.0:
     prop-types "^15.6.2"
     scheduler "^0.18.0"
 
-react-remove-scroll-bar@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/react-remove-scroll-bar/-/react-remove-scroll-bar-2.0.0.tgz#94437a7f3dbda99817ff64b928ee206e298ba157"
-  integrity sha512-HSdWZ+6vV6X1btLRhQlIcFulaMePCyg0Un2oXMmDdq8lK9KPUMSnWYINYWVCdgT35em9hiUaR8frBN1PYYLLpQ==
-  dependencies:
-    react-style-singleton "^2.0.0"
-    tslib "^1.0.0"
-
-react-remove-scroll@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/react-remove-scroll/-/react-remove-scroll-2.2.0.tgz#f42e6a4791ebfcce2c96f970d24deb1399fa9550"
-  integrity sha512-bT29xAkNuhS2tnsxhLNJrmmb6Rn8VsnlOfSoRaKdKi90DbhRcQfJ9vHG1TtgfkCP+rx059vCGIScPZaCWsyIKA==
-  dependencies:
-    react-remove-scroll-bar "^2.0.0"
-    react-style-singleton "^2.0.0"
-    tslib "^1.0.0"
-    use-callback-ref "^1.2.1"
-    use-sidecar "^1.0.1"
-
 react-side-effect@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/react-side-effect/-/react-side-effect-1.2.0.tgz#0e940c78faba0c73b9b0eba9cd3dda8dfb7e7dae"
@@ -15578,14 +15534,6 @@ react-sizeme@^2.6.7:
     invariant "^2.2.4"
     shallowequal "^1.1.0"
     throttle-debounce "^2.1.0"
-
-react-style-singleton@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/react-style-singleton/-/react-style-singleton-2.0.0.tgz#fdc9ff3a82674c256f0033d140b7b1d9d37e7f17"
-  integrity sha512-1Kw9G/b7EqLspjtiKsC9jtoqkx+RAti+8PmBe47ioKTcdhB3gtaKw2Lc3Hsud/VrXh+QECZKmr2yDCwR7ObNtA==
-  dependencies:
-    invariant "^2.2.4"
-    tslib "^1.0.0"
 
 react-syntax-highlighter@^8.0.1:
   version "8.1.0"
@@ -18133,7 +18081,7 @@ ts-pnp@^1.1.2:
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.1.5.tgz#840e0739c89fce5f3abd9037bb091dbff16d9dec"
   integrity sha512-ti7OGMOUOzo66wLF3liskw6YQIaSsBgc4GOAlWRnIEj8htCxJUxskanMUoJOD6MDCRAXo36goXJZch+nOS0VMA==
 
-tslib@1.10.0, tslib@^1.0.0, tslib@^1.6.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
+tslib@1.10.0, tslib@^1.0.0, tslib@^1.6.0, tslib@^1.8.1, tslib@^1.9.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
   integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
@@ -18612,11 +18560,6 @@ url@^0.11.0:
     punycode "1.3.2"
     querystring "0.2.0"
 
-use-callback-ref@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/use-callback-ref/-/use-callback-ref-1.2.1.tgz#898759ccb9e14be6c7a860abafa3ffbd826c89bb"
-  integrity sha512-C3nvxh0ZpaOxs9RCnWwAJ+7bJPwQI8LHF71LzbQ3BvzH5XkdtlkMadqElGevg5bYBDFip4sAnD4m06zAKebg1w==
-
 use-dark-mode@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/use-dark-mode/-/use-dark-mode-2.3.1.tgz#d506349c7b7e09e9977cb8a6ab4470896aa3779a"
@@ -18631,14 +18574,6 @@ use-persisted-state@^0.3.0:
   integrity sha512-UlWEq0JYg7NbvcRBZ1g6Bwe4SEbYfr1wr/D5mrmfCzSxXSwsPRYygGLlsxHcW58Rf7gGwRPBT23sNVvyVn4WYg==
   dependencies:
     "@use-it/event-listener" "^0.1.2"
-
-use-sidecar@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/use-sidecar/-/use-sidecar-1.0.2.tgz#e72f582a75842f7de4ef8becd6235a4720ad8af6"
-  integrity sha512-287RZny6m5KNMTb/Kq9gmjafi7lQL0YHO1lYolU6+tY1h9+Z3uCtkJJ3OSOq3INwYf2hBryCcDh4520AhJibMA==
-  dependencies:
-    detect-node "^2.0.4"
-    tslib "^1.9.3"
 
 use@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
`modulz-primitives` in it's latest version is starting to use `sx` property to styles components using the theme values (the way it should be done using `styled-system`). (cf https://github.com/modulz/radix/pull/219 and https://github.com/modulz/radix/pull/228)